### PR TITLE
Feat/docling parser

### DIFF
--- a/autorag/autorag/data/__init__.py
+++ b/autorag/autorag/data/__init__.py
@@ -15,6 +15,7 @@ from langchain_community.document_loaders import (
 	UnstructuredXMLLoader,
 	DirectoryLoader,
 )
+from langchain_docling import DoclingLoader
 from langchain_unstructured import UnstructuredLoader
 from langchain_upstage import UpstageDocumentParseLoader
 
@@ -45,6 +46,7 @@ parse_modules = {
 	"pypdf": PyPDFLoader,
 	"pymupdf": PyMuPDFLoader,
 	"unstructuredpdf": UnstructuredPDFLoader,
+ 	'docling':DoclingLoader, 
 	# Common File Types
 	# 1. CSV
 	"csv": CSVLoader,


### PR DESCRIPTION
This pull request introduces new CLI commands for parsing and chunking data, along with support for a new document loader. 

### New CLI Commands

* Added `parse` command to the CLI, which uses the `Parser` class to process data files based on a YAML configuration. The command includes options for specifying the YAML path, data glob pattern, project directory, and whether to process all files. (`autorag/autorag/cli.py`, [autorag/autorag/cli.pyR35-R104](diffhunk://#diff-7ca21ab58fc6c334eca1129c472ba7b091dd86fb5d8a3ec11591187ed75c2feaR35-R104))
* Added `chunk` command to the CLI, which uses the `Chunker` class to chunk parsed data files. The command includes options for specifying the YAML path, parsed data path, and project directory. (`autorag/autorag/cli.py`, [autorag/autorag/cli.pyR35-R104](diffhunk://#diff-7ca21ab58fc6c334eca1129c472ba7b091dd86fb5d8a3ec11591187ed75c2feaR35-R104))

### Enhanced File Type Support

* Introduced `DoclingLoader` to the `autorag` package, enabling the processing of Docling file types. (`autorag/autorag/data/__init__.py`, [[1]](diffhunk://#diff-4c1fa43c0b22d7fcbd012a9426e98ed6c9e9a545c2f9c58cae3d78e8fc952458R18) [[2]](diffhunk://#diff-4c1fa43c0b22d7fcbd012a9426e98ed6c9e9a545c2f9c58cae3d78e8fc952458R49)